### PR TITLE
Missing Part Fix and Handling Implant vs Part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+1.3/Source/GeneticRim/.vs/GeneticRim/FileContentIndex/a806683f-df41-4f45-b229-a953f7bc4809.vsidx
+1.3/Source/GeneticRim/.vs/GeneticRim/FileContentIndex/read.lock

--- a/1.3/Defs/HediffDefs/Hediffs_Local_Implants_Humanoid.xml
+++ b/1.3/Defs/HediffDefs/Hediffs_Local_Implants_Humanoid.xml
@@ -605,8 +605,7 @@
 	<HediffDef ParentName="GR_HybridPartsBase">
 		<defName>GR_ChemfuelStomach</defName>
 		<description>A reinforced bionic stomach that uses a combination of gastric acid and chemfuel to efficiently digest food.</description>
-		<label>humanoid implant: chemfuel stomach</label>
-		<hediffClass>Hediff_Implant</hediffClass>
+		<label>humanoid implant: chemfuel stomach</label>		
 		<stages>
 			<li>
 				<minSeverity>0</minSeverity>
@@ -699,8 +698,7 @@
 	<HediffDef ParentName="GR_HybridPartsBase">
 		<defName>GR_ChemfuelHeart</defName>
 		<description>A reinforced bionic heart that acts like a miniature 4-stroke internal combustion engine powered by chemfuel to pump blood through the body.</description>
-		<label>humanoid implant: chemfuel heart</label>
-		<hediffClass>Hediff_Implant</hediffClass>
+		<label>humanoid implant: chemfuel heart</label>		
 		<stages>
 		<li>
 				<minSeverity>0</minSeverity>
@@ -871,8 +869,7 @@
 		<spawnThingOnRemoved>GR_WolfMuscularFibers</spawnThingOnRemoved>
 	</HediffDef>
 	<HediffDef ParentName="GR_HybridPartsBase">
-		<defName>GR_DevouringJaws</defName>
-		<hediffClass>Hediff_Implant</hediffClass>
+		<defName>GR_DevouringJaws</defName>		
 		<description>A set of improved teeth designed to rapidly chew and ingest any kind of food. Leaves kind of a mess, though...</description>
 		<label>humanoid implant: devouring jaws</label>
 		<stages>
@@ -1073,8 +1070,7 @@
 		<spawnThingOnRemoved>GR_NeuronReinforcement</spawnThingOnRemoved>
 	</HediffDef>
 	<HediffDef ParentName="GR_HybridPartsBase">
-		<defName>GR_MousePheromones</defName>
-		<hediffClass>Hediff_Implant</hediffClass>
+		<defName>GR_MousePheromones</defName>		
 		<description>A bionic vomeronasal organ that allows the subject pheromonal communication with other animals, increasing the chance of taming and training them successfully.</description>
 		<addedPartProps>
 			<partEfficiency>1.1</partEfficiency>
@@ -1141,8 +1137,7 @@
 		<spawnThingOnRemoved>GR_MousePheromones</spawnThingOnRemoved>
 	</HediffDef>
 	<HediffDef ParentName="GR_HybridPartsBase">
-		<defName>GR_MoleratNerveDampener</defName>
-		<hediffClass>Hediff_Implant</hediffClass>
+		<defName>GR_MoleratNerveDampener</defName>		
 		<description>A biochip that reduces pain sensitivity, allowing the subject to survive pain shock.</description>
 		<addedPartProps>
 			<partEfficiency>1.1</partEfficiency>
@@ -1601,8 +1596,7 @@
 	</HediffDef>
 	<HediffDef ParentName="GR_HybridPartsBase">
 		<defName>GR_HumanThrumboHorn</defName>
-		<description>A genetically modified thrumbo horn that can be implanted in a subject's forehead. Nasty.</description>
-		<hediffClass>Hediff_Implant</hediffClass>
+		<description>A genetically modified thrumbo horn that can be implanted in a subject's forehead. Nasty.</description>		
 		<label>humanoid implant: thrumbo horn</label>
 		<addedPartProps>
 			<partEfficiency>1.2</partEfficiency>

--- a/1.3/Defs/RecipeDefs/Recipes_Surgery_Implants_Humanoid.xml
+++ b/1.3/Defs/RecipeDefs/Recipes_Surgery_Implants_Humanoid.xml
@@ -45,17 +45,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_BearClaws</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveBearClawsImplant</defName>
-		<label>remove bear claws implant</label>
-		<description>Remove bear claws implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_BearClaws</ThingDef>
-			<HediffDef>GR_BearClaws</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing bear claws implant.</jobString>
-		<removesHediff>GR_BearClaws</removesHediff>
-	</RecipeDef>
+	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallDiggingBearClaws</defName>
@@ -98,17 +88,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_DiggingBearClaws</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveDiggingBearClawsImplant</defName>
-		<label>remove digging mole claws implant</label>
-		<description>Remove digging mole claws implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_DiggingBearClaws</ThingDef>
-			<HediffDef>GR_DiggingBearClaws</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing digging mole claws implant.</jobString>
-		<removesHediff>GR_DiggingBearClaws</removesHediff>
-	</RecipeDef>
+	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallBearMuscleTissue</defName>
@@ -525,17 +505,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_ChemfuelStomach</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveChemfuelStomachImplant</defName>
-		<label>remove chemfuel stomach implant</label>
-		<description>Remove chemfuel stomach implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_ChemfuelStomach</ThingDef>
-			<HediffDef>GR_ChemfuelStomach</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing chemfuel stomach implant.</jobString>
-		<removesHediff>GR_ChemfuelStomach</removesHediff>
-	</RecipeDef>
+	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallChemfuelHeart</defName>
@@ -577,17 +547,6 @@
 			<li>Heart</li> 
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_ChemfuelHeart</addsHediff>
-	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveChemfuelHeartImplant</defName>
-		<label>remove chemfuel heart implant</label>
-		<description>Remove chemfuel heart implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_ChemfuelHeart</ThingDef>
-			<HediffDef>GR_ChemfuelHeart</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing chemfuel heart implant.</jobString>
-		<removesHediff>GR_ChemfuelHeart</removesHediff>
 	</RecipeDef>
 
 	<RecipeDef ParentName="SurgeryFlesh">
@@ -683,18 +642,8 @@
 			<li>Jaw</li> 
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_DevouringJaws</addsHediff>
-	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveDevouringJawsImplant</defName>
-		<label>remove devouring jaws implant</label>
-		<description>Remove devouring jaws implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_DevouringJaws</ThingDef>
-			<HediffDef>GR_DevouringJaws</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing devouring jaws implant.</jobString>
-		<removesHediff>GR_DevouringJaws</removesHediff>
-	</RecipeDef>
+	</RecipeDef>	
+	
 
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallNeuronReinforcement</defName>
@@ -792,18 +741,7 @@
 			<li>Nose</li> 
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_MousePheromones</addsHediff>
-	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveMousePheromonesImplant</defName>
-		<label>remove mouse pheromones implant</label>
-		<description>Remove mouse pheromones implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_MousePheromones</ThingDef>
-			<HediffDef>GR_MousePheromones</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing mouse pheromones implant.</jobString>
-		<removesHediff>GR_MousePheromones</removesHediff>
-	</RecipeDef>
+	</RecipeDef>	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallMoleratNerveDampener</defName>
@@ -846,17 +784,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_MoleratNerveDampener</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveMoleratNerveDampenerImplant</defName>
-		<label>remove mole-rat nerve dampener implant</label>
-		<description>Remove mole-rat nerve dampener implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_MoleratNerveDampener</ThingDef>
-			<HediffDef>GR_MoleratNerveDampener</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing mole-rat nerve dampener implant.</jobString>
-		<removesHediff>GR_MoleratNerveDampener</removesHediff>
-	</RecipeDef>
+	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallBunnyEars</defName>
@@ -899,17 +827,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_BunnyEars</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveBunnyEarsImplant</defName>
-		<label>remove bunny ear implant</label>
-		<description>Remove bunny ear implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_BunnyEars</ThingDef>
-			<HediffDef>GR_BunnyEars</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing bunny ear implant.</jobString>
-		<removesHediff>GR_BunnyEars</removesHediff>
-	</RecipeDef>
+
 
 	
 	<RecipeDef ParentName="SurgeryFlesh">
@@ -954,18 +872,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_CompoundEye</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveCompoundEyeImplant</defName>
-		<label>remove compound eye implant</label>
-		<description>Remove compound eye implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_CompoundEye</ThingDef>
-			<HediffDef>GR_CompoundEye</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing compound eye implant.</jobString>
-		<removesHediff>GR_CompoundEye</removesHediff>
-	</RecipeDef>
-	
+
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallCatEye</defName>
 		<label>&lt;color=#E89D1B&gt;install cat eye&lt;/color&gt;</label>
@@ -1008,17 +915,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_CatEye</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveCatEyeImplant</defName>
-		<label>remove cat eye implant</label>
-		<description>Remove cat eye implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_CatEye</ThingDef>
-			<HediffDef>GR_CatEye</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing cat eye implant.</jobString>
-		<removesHediff>GR_CatEye</removesHediff>
-	</RecipeDef>
+	
 	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
@@ -1063,17 +960,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_InsectoidAntennae</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveInsectoidAntennaeImplant</defName>
-		<label>remove insectoid antennae implant</label>
-		<description>Remove insectoid antennae implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_InsectoidAntennae</ThingDef>
-			<HediffDef>GR_InsectoidAntennae</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing insectoid antennae implant.</jobString>
-		<removesHediff>GR_InsectoidAntennae</removesHediff>
-	</RecipeDef>
+	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallPsychicDampeners</defName>
@@ -1169,17 +1056,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_KidneyToxicFilters</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveKidneyToxicFiltersImplant</defName>
-		<label>remove kidney toxic filters implant</label>
-		<description>Remove kidney toxic filters implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_KidneyToxicFilters</ThingDef>
-			<HediffDef>GR_KidneyToxicFilters</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing kidney toxic filters implant.</jobString>
-		<removesHediff>GR_KidneyToxicFilters</removesHediff>
-	</RecipeDef>
+	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallHumanThrumboHorn</defName>
@@ -1222,17 +1099,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_HumanThrumboHorn</addsHediff>
 	</RecipeDef>
-	<RecipeDef ParentName="SurgeryRemoveImplantBase">
-		<defName>GR_RemoveHumanThrumboHornImplant</defName>
-		<label>remove thrumbo horn implant</label>
-		<description>Remove thrumbo horn implant.</description>
-		<descriptionHyperlinks>
-			<ThingDef>GR_HumanThrumboHorn</ThingDef>
-			<HediffDef>GR_HumanThrumboHorn</HediffDef>
-		</descriptionHyperlinks>
-		<jobString>Removing thrumbo horn implant.</jobString>
-		<removesHediff>GR_HumanThrumboHorn</removesHediff>
-	</RecipeDef>
+	
 	
 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>GR_InstallThrumboSkin</defName>
@@ -1328,6 +1195,7 @@
 		</appliedOnFixedBodyParts>
 		<addsHediff>GR_VenomousFangs</addsHediff>
 	</RecipeDef>
+	
 	<RecipeDef ParentName="SurgeryRemoveImplantBase">
 		<defName>GR_RemoveVenomousFangsImplant</defName>
 		<label>remove venomous fangs implant</label>

--- a/1.3/Source/GeneticRim/GeneticRim/GeneticRim.csproj
+++ b/1.3/Source/GeneticRim/GeneticRim/GeneticRim.csproj
@@ -401,6 +401,7 @@
     <Compile Include="Gas and Liquid\Persistant_Fuel.cs" />
     <Compile Include="Harmony\Building_Trap_CheckSpring.cs" />
     <Compile Include="Harmony\Caravan_NightResting.cs" />
+    <Compile Include="Harmony\MedicalRecipesUtility_ApplyOnPawn.cs" />
     <Compile Include="Harmony\ExecutionUtility_ExecutionInt.cs" />
     <Compile Include="Harmony\Recipe_InstallArtificialBodyPart_ApplyOnPawn.cs" />
     <Compile Include="Harmony\Thing_ButcherProducts.cs" />

--- a/1.3/Source/GeneticRim/GeneticRim/Harmony/MedicalRecipesUtility_ApplyOnPawn.cs
+++ b/1.3/Source/GeneticRim/GeneticRim/Harmony/MedicalRecipesUtility_ApplyOnPawn.cs
@@ -1,0 +1,41 @@
+﻿using HarmonyLib;
+using Verse;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace GeneticRim
+{
+    [HarmonyPatch(typeof(MedicalRecipesUtility))]
+    [HarmonyPatch("SpawnThingsFromHediffs")]
+    public static class VanillaGeneticsExpanded_MedicalRecipesUtility_SpawnThingsFromHediffs_Prefix
+    {
+        
+
+        [HarmonyPrefix]
+        public static void AddQualityToImplant(Pawn pawn, BodyPartRecord part)
+        {
+            Log.Message("Got to Here for" + part.Label);
+            foreach (Hediff hediff in from x in pawn.health.hediffSet.hediffs
+            where x.Part == part
+            select x)
+            if (hediff != null)
+            {
+                if (hediff.def.spawnThingOnRemoved != null)
+                {
+                    var comp = hediff.TryGetComp<HediffCompImplantQuality>();
+                    if (comp != null)
+                    {
+                        VanillaGeneticsExpanded_Recipe_RemoveImplant_ApplyOnPawn_Prefix.implantQuality = new Pair<ThingDef, QualityCategory>(hediff.def.spawnThingOnRemoved, comp.quality); //Setting other patches pair to not have to duplicate spawn postfix
+                    }
+                }
+            }            
+
+        }
+
+    }    
+}

--- a/1.3/Source/GeneticRim/GeneticRim/Harmony/MedicalRecipesUtility_ApplyOnPawn.cs
+++ b/1.3/Source/GeneticRim/GeneticRim/Harmony/MedicalRecipesUtility_ApplyOnPawn.cs
@@ -18,8 +18,7 @@ namespace GeneticRim
 
         [HarmonyPrefix]
         public static void AddQualityToImplant(Pawn pawn, BodyPartRecord part)
-        {
-            Log.Message("Got to Here for" + part.Label);
+        {           
             foreach (Hediff hediff in from x in pawn.health.hediffSet.hediffs
             where x.Part == part
             select x)

--- a/1.3/Source/GeneticRim/GeneticRim/Recipes/Recipe_InstallGeneticBodyPart.cs
+++ b/1.3/Source/GeneticRim/GeneticRim/Recipes/Recipe_InstallGeneticBodyPart.cs
@@ -38,11 +38,8 @@ namespace GeneticRim
 					return;
 				}
 				TaleRecorder.RecordTale(TaleDefOf.DidSurgery, billDoer, pawn);
-
-				if (!pawn.health.hediffSet.GetNotMissingParts(BodyPartHeight.Undefined, BodyPartDepth.Undefined, null, null).Contains(part))//Making it only happen when missing part. Unsure if necessary 				
-				{
-					pawn.health.RestorePart(part); //Added to see if it fixes issue with missing part
-				}
+				MedicalRecipesUtility.RestorePartAndSpawnAllPreviousParts(pawn, part, billDoer.Position, billDoer.Map); //Adding this back as I believe infinite part issues will be resolved.
+				
 
 				if (flag && flag2 && part.def.spawnThingOnRemoved != null)
 				{

--- a/1.3/Source/GeneticRim/GeneticRim/Recipes/Recipe_InstallGeneticBodyPart.cs
+++ b/1.3/Source/GeneticRim/GeneticRim/Recipes/Recipe_InstallGeneticBodyPart.cs
@@ -38,7 +38,12 @@ namespace GeneticRim
 					return;
 				}
 				TaleRecorder.RecordTale(TaleDefOf.DidSurgery, billDoer, pawn);
-				
+
+				if (!pawn.health.hediffSet.GetNotMissingParts(BodyPartHeight.Undefined, BodyPartDepth.Undefined, null, null).Contains(part))//Making it only happen when missing part. Unsure if necessary 				
+				{
+					pawn.health.RestorePart(part); //Added to see if it fixes issue with missing part
+				}
+
 				if (flag && flag2 && part.def.spawnThingOnRemoved != null)
 				{
 					ThoughtUtility.GiveThoughtsForPawnOrganHarvested(pawn, billDoer);


### PR DESCRIPTION
Summary of changes

Recipe_InstallGeneticBodyPart - Put this basically back to Vanilla with the MedicalRecipesUtility as other fixes handle exploit issues with it

New Patch - MedicalRecipesUtility_ApplyOnPawn - hooked into here for the fetching of hediff quality on the vanillla remove bodypart. It saves it to the Remove Implant class. The actual spawn patch remains unchanged in the Remove Implant patch. (This could probably be removed to its own class for cleanup but \o/)

XML Changes:
Recipes_Surgery_Implants_Humanoid - Removed the Remove Recipes of all body parts that aren't implants, but actual body parts.

Heddifs_Local_Implants_Humanoid- Removed the <hediffClass>Hediff_Implant</hediffClass> on all the body parts I removed the recipe for as this prevents the Remove Part recipe from being added. It was on some parts and not others. Eg Venom jaws didnt have it but Devouring Jaws did. For minimal mods a lot of this doesn't matter, but with mods that add eyes, ears etc as harvestable organs then it without this you could print eyeballs.